### PR TITLE
[Add]食品詳細ダイアログの実装#10

### DIFF
--- a/app/javascript/pages/food/components/FoodBarChart.vue
+++ b/app/javascript/pages/food/components/FoodBarChart.vue
@@ -52,8 +52,8 @@ export default {
   props: {
     food: {
       type: Object,
-      default: null
-    }
+      required: true
+    },
   },
   mounted() {
     this.renderChart(

--- a/app/javascript/pages/food/dialog.vue
+++ b/app/javascript/pages/food/dialog.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-card>
+    <v-card-title class="text-h5 white">
+      <p>{{ food.name }}</p>
+      <v-spacer />
+      <p>税抜{{ food.price }}円</p>
+    </v-card-title>
+    <v-card-subtitle class="text-h6 text-right">
+      <p>{{ food.calorie }}kcal</p>
+    </v-card-subtitle>
+    <v-row justify="center">
+      <v-col cols="10">
+        <v-img :src="food.image.url" />
+      </v-col>
+      <v-col cols="10">
+        <FoodBarChart
+          :key="food.id"
+          :food="food"
+        />
+      </v-col>
+      <v-col
+        cols="4"
+        offset="1"
+      >
+        <v-btn
+          class="mx-auto"
+          x-large
+          outlined
+          elevation="3"
+        >
+          選択する
+        </v-btn>
+      </v-col>
+      <v-col
+        cols="4"
+        offset="1"
+      >
+        <v-btn
+          class="mx-auto"
+          x-large
+          outlined
+          elevation="3"
+          @click="closeDialog"
+        >
+          閉じる
+        </v-btn>
+      </v-col>
+    </v-row>
+  </v-card>
+</template>
+
+<script>
+import { mapActions, mapGetters } from "vuex";
+import FoodBarChart from './components/FoodBarChart.vue'
+
+export default {
+  components: {
+    FoodBarChart
+  },
+  computed: {
+    ...mapGetters(["food_dialog", "food"])
+  },
+  methods: {
+    ...mapActions(["closeDialog"]),
+    close(e) {
+      console.log('close', e)
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/javascript/pages/food/index.vue
+++ b/app/javascript/pages/food/index.vue
@@ -10,6 +10,7 @@
         <v-card
           class="my-5"
           outlined
+          @click="openDialog(food)"
         > 
           <v-row justify="center">
             <v-col cols="4">
@@ -21,7 +22,7 @@
                 税抜{{ food.price }}円
               </v-card-subtitle>
               <v-card-subtitle class="text-h6">
-                カロリー {{ food.calorie }}kcal
+                {{ food.calorie }}kcal
               </v-card-subtitle>
             </v-col>
             <v-col cols="6">
@@ -31,6 +32,15 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-dialog
+      v-model="food_dialog"
+      width="600"
+      max-height="300"
+      persistent
+      @click:outside="closeDialog"
+    >
+      <Dialog />
+    </v-dialog>
     <infinite-loading
       v-if="hasNext"
       spinner="spiral"
@@ -48,14 +58,16 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 import FoodBarChart from "./components/FoodBarChart.vue"
 import InfiniteLoading from 'vue-infinite-loading';
+import Dialog from './dialog.vue'
 
 export default {
   components: {
     FoodBarChart,
-    InfiniteLoading, 
+    InfiniteLoading,
+    Dialog
   },
   data() {
     return {
@@ -68,7 +80,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["foods"]),
+    ...mapGetters(["foods", "food_dialog"]),
     hasNext() {
       return this.initialized
     }
@@ -94,6 +106,7 @@ export default {
     this.fetchFoods(null, this.start, false)
   },
   methods: {
+    ...mapActions(["openDialog", "closeDialog"]),
     infiniteHandler($state) {
       if (this.end >= this.totalPages) {
       // 全てのページが読まれたことをプラグインに伝える

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -8,13 +8,17 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     drawer: false,
+    food_dialog: false,
     user: null,
-    foods: null
+    foods: null,
+    food: null
   },
   getters: {
     drawer: state => state.drawer,
+    food_dialog: state => state.food_dialog,
     user: state => state.user,
-    foods: state => state.foods
+    foods: state => state.foods,
+    food: state => state.food
   },
   mutations: {
     changeDrawer(state) {
@@ -25,8 +29,14 @@ export default new Vuex.Store({
     },
     foodList(state, data) {
       state.foods = data
-      console.log(state.foods)
       router.push('foods')
+    },
+    openDialog(state, food_data) {
+      state.food = food_data
+      state.food_dialog = true
+    },
+    closeDialog(state) {
+      state.food_dialog = false
     }
   },
   actions: {
@@ -102,10 +112,11 @@ export default new Vuex.Store({
         console.log(err)
       })
     },
-    // async fetchFoods({ commit, state}, loadState) {
-    //   const data = await axios.get
-    // }
-
-    // }
+    openDialog({ commit }, food_data) {
+      commit('openDialog', food_data)
+    },
+    closeDialog({ commit }) {
+      commit('closeDialog')
+    }
   }
 })


### PR DESCRIPTION
## 概要

**食品一覧ページにて食品をクリック　→　食品詳細ページ描画を実装いたしました**

[![Image from Gyazo](https://i.gyazo.com/8d6d4684d19c3fb5c8cb63e8a69d8b9e.gif)](https://gyazo.com/8d6d4684d19c3fb5c8cb63e8a69d8b9e)


## チェックリスト

- [x] chart.jsを使用し、横棒グラフにて各栄養素を表示する
- [x] 画像を表示する
- [x] 閉じるボタン、ダイアログ外を押すと画面が閉じる


## コメント

- 一覧ページと詳細ページを同じグラフを用いているため、フィードバック次第で変更予定
- 商品ダイアログにてスクロールし画面を閉じた後、別商品を参照すると、ある程度スクロールしたところで表示されてしまう。ここは改良の余地があると思うため、issueに残す
