### PR TITLE
[Change]栄養素の表記、順番の統一#64

### DIFF
--- a/app/javascript/pages/food/components/FoodCurrentNutrient.vue
+++ b/app/javascript/pages/food/components/FoodCurrentNutrient.vue
@@ -16,7 +16,7 @@
             md="3"
           >
             <p>
-              タンパク質<br>
+              たんぱく質<br>
               {{ current_nutrients.protein }}g
             </p>
           </v-col>

--- a/app/javascript/pages/food/search.vue
+++ b/app/javascript/pages/food/search.vue
@@ -23,7 +23,7 @@
               justify="center"
             >
               <v-col cols="5">
-                <label>タンパク質</label>
+                <label>たんぱく質</label>
                 <v-text-field 
                   v-model.number="nutrients.proteinValue.minimum"
                   dense

--- a/app/javascript/pages/user/calorie/result.vue
+++ b/app/javascript/pages/user/calorie/result.vue
@@ -28,7 +28,7 @@
         class="mt-15"
       >
         <h2 class="text-center">
-          炭水化物{{ ingestionCal["carbohydrate"] }}g
+          たんぱく質{{ ingestionCal["protein"] }}g
         </h2>
       </v-col>
       <v-col
@@ -36,7 +36,7 @@
         class="mt-15"
       >
         <h2 class="text-center">
-          タンパク質{{ ingestionCal["protein"] }}g
+          炭水化物{{ ingestionCal["carbohydrate"] }}g
         </h2>
       </v-col>
       <v-col


### PR DESCRIPTION
## 概要

- たんぱく質　ひらがな表記の統一
- 栄養素表示の順番を、「たんぱく質」「炭水化物」「脂質」の順番に統一

- 修正前
[![Image from Gyazo](https://i.gyazo.com/39eda12fa08483b9fbb354d55464d883.png)](https://gyazo.com/39eda12fa08483b9fbb354d55464d883)

- 修正後
[![Image from Gyazo](https://i.gyazo.com/6b1c0180e34b076abfe86fc640d004f9.png)](https://gyazo.com/6b1c0180e34b076abfe86fc640d004f9)