### PR TITLE
[Add]買い物アイコンに商品数を追加#59

### DIFF
--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -44,7 +44,16 @@
         to="/confirmation"
       >
         <v-btn icon>
-          <v-icon>mdi-cart</v-icon>
+          <v-badge
+            :content="selectedFoodNumber"
+            :value="selectedFoodNumber"
+            color="red"
+            overlap
+          >          
+            <v-icon large>
+              mdi-cart
+            </v-icon>
+          </v-badge>
         </v-btn>
       </router-link>
     </template>
@@ -53,15 +62,15 @@
 
 
 <script>
-import { mapActions } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 export default {
-  // data() {
-  //   return {
-  //     logoImg: require("../../assets/images/logo.png")
-  //   }
   computed: {
+    ...mapGetters(["selectFoods"]),
     isAutheniticated() {
       return this.$store.getters.user !== null;
+    },
+    selectedFoodNumber() {
+      return this.selectFoods.length
     }
   },
   methods: {
@@ -71,6 +80,6 @@ export default {
         this.$router.push("/")
       }
     }
-  }
+  },
 }
 </script>

--- a/app/javascript/pages/food/index.vue
+++ b/app/javascript/pages/food/index.vue
@@ -100,7 +100,7 @@ export default {
       data: [], // 新しく取得したデータ。getFoodsと結合する
       page: 0,
       pageSize: 20, // １ページに表示するデータ件数
-      initialized: false, //初回データアクセスが完了した後にtrueを設定するフラグ
+      initialized: false, //データアクセスが完了した後にtrueを設定するフラグ
     }
   },
   computed: {
@@ -144,7 +144,7 @@ export default {
         this.fetchFoods($state, this.page + 1)
       }
     },
-    //                 1, 
+    //                 
     fetchFoods($state, page) {
       // setTimeout(() => {
         this.data = this.foods.slice(page * this.pageSize - this.pageSize, page * this.pageSize)


### PR DESCRIPTION
## 概要

買い物アイコンに商品数を表示
[![Image from Gyazo](https://i.gyazo.com/225802f2445bd0e25f237652a1e1c91e.png)](https://gyazo.com/225802f2445bd0e25f237652a1e1c91e)

## コメント
削除する際、
`vuetify.js:40103 Uncaught DOMException: Failed to execute
 'removeChild' on 'Node': The node to be removed is not a child of this node.`  
`vuetify.js:40103 Uncaught DOMException: Failed to execute
 'removeChild' on 'Node': 削除されるノードは、このノードの子ではありません。`  
というエラーが出るが、
[公式](https://developer.mozilla.org/ja/docs/Web/API/Node/removeChild)いわく、元々DOM上に存在していた子要素がイベントなどで削除される際に、出される例外とのこと。メモリも削除されるとのことであり、特段影響がないと考えることから、このままプルリクをあげる

